### PR TITLE
Pull Jenkins URL from env var instead of param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,18 @@ If your Heroku application is running at http://myapp-123.herokuapp.com, you
 should now add a WebHook to your GitHub project. Use the following URL as a
 template, removing newlines which have been added here for clarity:
 
-    http://myapp-123.herokuapp.com/build?jenkins_url=<root_url>
-                                        &jenkins_job=<job_name>
+    http://myapp-123.herokuapp.com/build?jenkins_job=<job_name>
                                         &jenkins_token=<token>
 
 For example:
 
-    http://myapp-123.herokuapp.com/build?jenkins_url=http://jenkins.acmecorp.com
-                                        &jenkins_job=acme-product
+    http://myapp-123.herokuapp.com/build?jenkins_job=acme-product
                                         &jenkins_token=4e7ea85b-8ed0-458f-a055-e18519cde94b
+
+You will need to set the base URL for your jenkins instance via an environment variable,
+for example:
+
+    heroku config set JENKINS_URL=https://jenkins.example.com
 
 Other optional parameters include:
 

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 DEBUG           = environ.get('DEBUG', 'false') == 'true'
 IGNORE_BRANCHES = [b for b in environ.get('IGNORE_BRANCHES', '').split(',') if b != '']
 REF_PREFIX      = 'refs/heads/'
+JENKINS_URL     = environ.get('JENKINS_URL', '')
 
 app.config.from_object(__name__)
 
@@ -33,17 +34,19 @@ def require_arg(name, default=None):
 
 @app.route('/build', methods=('POST',))
 def build():
+    if JENKINS_URL == '':
+        abort('Environment variable JENKINS_URL was not set')
+
     payload = _get_payload()
     branch = _get_branch(payload)
 
     jenkins_job       = require_arg('jenkins_job')
     jenkins_token     = require_arg('jenkins_token')
-    jenkins_url       = require_arg('jenkins_url')
     jenkins_user      = request.args.get('jenkins_user')
     jenkins_password  = request.args.get('jenkins_password', '')
     jenkins_param_key = require_arg('jenkins_param_key', 'BRANCH')
 
-    url = '{jenkins_url}/job/{jenkins_job}/buildWithParameters'.format(**vars())
+    url = '{JENKINS_URL}/job/{jenkins_job}/buildWithParameters'.format(**vars())
     params = {'token': jenkins_token,
               jenkins_param_key: branch}
 


### PR DESCRIPTION
This allows us to change the URL across the board
from one place without having to update each webhook.
