### PR TITLE
Don't follow redirects when connecting to Jenkins

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,7 +73,7 @@ def build():
     auth = None
     if jenkins_user is not None:
         auth = (jenkins_user, jenkins_password)
-    res = requests.get(url, params=params, auth=auth, timeout=10)
+    res = requests.get(url, params=params, auth=auth, timeout=10, allow_redirects=False)
 
     if res.ok:
         log.debug('Request submitted successfully to %s with params %s', url, params)


### PR DESCRIPTION
Jenkins will issue a 302 redirect when you ask it to build a job, but it will redirect you from HTTPS to HTTP. We firewall HTTP port 80 now.

Paired with @jennyd.